### PR TITLE
Compatibility with subprocess

### DIFF
--- a/_posixsubprocess.c
+++ b/_posixsubprocess.c
@@ -27,6 +27,11 @@
 #include <dirent.h>
 #endif
 
+/* Older OSes doesn't support PIPE2 if O_CLOEXEC is not defined */
+#ifndef O_CLOEXEC
+# undef HAVE_PIPE2
+#endif
+
 #if defined(__ANDROID__) && !defined(SYS_getdents64)
 /* Android doesn't expose syscalls, add the definition manually. */
 # include <sys/linux-syscalls.h>

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def main():
 
     setup(
       name='subprocess32',
-      version='3.2.7+scale1',
+      version='3.2.7+scale2',
       description='A backport of the subprocess module from Python 3.2/3.3 for use on 2.x.',
       long_description="""
 This is a backport of the subprocess standard library module from

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def main():
 
     setup(
       name='subprocess32',
-      version='3.2.7+scale2',
+      version='3.2.7+scale3',
       description='A backport of the subprocess module from Python 3.2/3.3 for use on 2.x.',
       long_description="""
 This is a backport of the subprocess standard library module from

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def main():
 
     setup(
       name='subprocess32',
-      version='3.2.7',
+      version='3.2.7+scale1',
       description='A backport of the subprocess module from Python 3.2/3.3 for use on 2.x.',
       long_description="""
 This is a backport of the subprocess standard library module from

--- a/subprocess32.py
+++ b/subprocess32.py
@@ -1413,7 +1413,7 @@ class Popen(_PopenBase):
                 try:
 
                     if _posixsubprocess:
-                        fs_encoding = sys.getfilesystemencoding()
+                        fs_encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
                         def fs_encode(s):
                             """Encode s for use in the env, fs or cmdline."""
                             if isinstance(s, str):

--- a/subprocess32.py
+++ b/subprocess32.py
@@ -414,19 +414,30 @@ import traceback
 import gc
 import signal
 
+
 # Exception classes used by this module.
-class CalledProcessError(Exception):
-    """This exception is raised when a process run by check_call() or
-    check_output() returns a non-zero exit status.
-    The exit status will be stored in the returncode attribute;
-    check_output() will also store the output in the output attribute.
-    """
-    def __init__(self, returncode, cmd, output=None):
-        self.returncode = returncode
-        self.cmd = cmd
-        self.output = output
-    def __str__(self):
-        return "Command '%s' returned non-zero exit status %d" % (self.cmd, self.returncode)
+
+try:
+    # For compatibility with subprocess try to use the original exception
+    # class.
+    from subprocess import CalledProcessError
+except ImportError:
+    # In case this module was installed as subprocess as suggested in
+    # README.md the import above will refer to this module, therefore the
+    # CalledProcessError is not defined yet.
+
+    class CalledProcessError(Exception):
+        """This exception is raised when a process run by check_call() or
+        check_output() returns a non-zero exit status.
+        The exit status will be stored in the returncode attribute;
+        check_output() will also store the output in the output attribute.
+        """
+        def __init__(self, returncode, cmd, output=None):
+            self.returncode = returncode
+            self.cmd = cmd
+            self.output = output
+        def __str__(self):
+            return "Command '%s' returned non-zero exit status %d" % (self.cmd, self.returncode)
 
 
 class TimeoutExpired(Exception):
@@ -712,7 +723,13 @@ def list2cmdline(seq):
 _PLATFORM_DEFAULT_CLOSE_FDS = object()
 
 
-class Popen(object):
+try:
+    from subprocess import Popen as _PopenBase
+except ImportError:
+    _PopenBase = object
+
+
+class Popen(_PopenBase):
     def __init__(self, args, bufsize=0, executable=None,
                  stdin=None, stdout=None, stderr=None,
                  preexec_fn=None, close_fds=_PLATFORM_DEFAULT_CLOSE_FDS,

--- a/test_subprocess32.py
+++ b/test_subprocess32.py
@@ -2157,6 +2157,22 @@ class CompatibilityTests(BaseTestCase):
                 assert issubclass(new_value, old_value), \
                        "Incompatible type vs. stock subprocess: {0}".format(name)
 
+    def test_completeness(self):
+        """
+        Each name in subprocess exists in subprocess32 as well.
+        """
+        import subprocess as stock_subprocess
+        if stock_subprocess is subprocess32:
+            self.skipTest("subprocess32 is installed as stock subprocess")
+
+        missing_names = set(dir(stock_subprocess)) - set(dir(subprocess32))
+
+        # Nobody in their right mind would call the _demo functions from outside
+        missing_names -= set(["_demo_posix", "_demo_windows"])
+
+        assert not missing_names, \
+                "Missing in subprocess32: {0}".format(missing_names)
+
 
 if sys.version_info[:2] <= (2,4):
     # The test suite hangs during the pure python test on 2.4.  No idea why.

--- a/test_subprocess32.py
+++ b/test_subprocess32.py
@@ -2139,6 +2139,25 @@ class ContextManagerTests(BaseTestCase):
             self.fail("Expected an EnvironmentError exception.")
 
 
+class CompatibilityTests(BaseTestCase):
+
+    def test_compatible_types(self):
+        """
+        To allow for interoperability all classes in subprocess32 should
+        be subclasses of the stock subprocess classes.
+        """
+        import subprocess as stock_subprocess
+        if stock_subprocess is subprocess32:
+            self.skipTest("subprocess32 is installed as stock subprocess")
+
+        for name in dir(subprocess32):
+            new_value = getattr(subprocess32, name)
+            old_value = getattr(subprocess, name, None)
+            if old_value is not None and isinstance(old_value, type):
+                assert issubclass(new_value, old_value), \
+                       "Incompatible type vs. stock subprocess: {0}".format(name)
+
+
 if sys.version_info[:2] <= (2,4):
     # The test suite hangs during the pure python test on 2.4.  No idea why.
     # That is not the implementation anyone is using this module for anyways.
@@ -2153,7 +2172,8 @@ def test_main():
                   ProcessTestCasePOSIXPurePython,
                   ProcessTestCaseNoPoll,
                   HelperFunctionTests,
-                  ContextManagerTests)
+                  ContextManagerTests,
+                  CompatibilityTests)
 
     test_support.run_unittest(*unit_tests)
     reap_children()


### PR DESCRIPTION
While the README.md suggests that subprocess32 can replace subprocess, this does not seem the case with a current CPython 2.7 since multiprocessing uses a protected function in subprocess not provided by subprocess32.

Also just doing `import subprocess32 as subprocess` causes problems if other code still imports subprocess directly and tries to catch exceptions like CalledProcessError. This commit tries to mimic the original API more closely.
