### PR TITLE
Remove the sys.exit(1) when setup.py is run on PY3.

### DIFF
--- a/python3_redirect/__init__.py
+++ b/python3_redirect/__init__.py
@@ -1,4 +1,4 @@
-"""When installed as subprocess32.py, this sets up a redirect to subprocess."""
+"""When installed as subprocess32, this sets up a redirect to subprocess."""
 
 import subprocess
 import sys

--- a/python3_redirect/__init__.py
+++ b/python3_redirect/__init__.py
@@ -1,0 +1,9 @@
+"""When installed as subprocess32.py, this sets up a redirect to subprocess."""
+
+import subprocess
+import sys
+if sys.version_info[:2] < (3,3):
+    raise ImportError('Ancient Python 3 versions are not supported.')
+# Doing this could crash some older Python interpreters due to the module
+# reference going away before the import is complete?
+sys.modules['subprocess32'] = subprocess

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 import os
 import sys
@@ -6,28 +6,38 @@ from distutils.core import setup, Extension
 
 
 def main():
-    if sys.version_info[0] != 2:
-        sys.stderr.write('This backport is for Python 2.x only.\n')
-        sys.exit(1)
-
-    ext = Extension('_posixsubprocess', ['_posixsubprocess.c'],
-                    depends=['_posixsubprocess_helpers.c'])
-    if os.name == 'posix':
-        ext_modules = [ext]
-    else:
-        ext_modules = []
+    ext_modules = []
+    py_modules = []
+    packages = []
+    package_dir = {}
+    if sys.version_info[0] == 2:  # PY2
+        py_modules.append('subprocess32')
+        if os.name == 'posix':
+            ext = Extension('_posixsubprocess', ['_posixsubprocess.c'],
+                            depends=['_posixsubprocess_helpers.c'])
+            ext_modules.append(ext)
+    else:  # PY3
+        # Install a redirect that makes subprocess32 == subprocess on import.
+        packages.append('subprocess32')
+        package_dir['subprocess32'] = 'python3_redirect'
+        sys.stderr.write('subprocess32 == subprocess on Python 3.\n')
 
     setup(
       name='subprocess32',
-      version='3.2.7',
+      version='3.2.8.dev',
       description='A backport of the subprocess module from Python 3.2/3.3 for use on 2.x.',
-      long_description="""
+      long_description="""\
 This is a backport of the subprocess standard library module from
 Python 3.2 & 3.3 for use on Python 2.
+
 It includes bugfixes and some new features.  On POSIX systems it is
 guaranteed to be reliable when used in threaded applications.
 It includes timeout support from Python 3.3 but otherwise matches
-3.2's API.  It has not been tested on Windows.""",
+3.2's API.
+
+It has not been tested by the author on Windows.
+
+On Python 3, it merely redirects the subprocess32 name to subprocess.""",
       license='PSF license',
 
       maintainer='Gregory P. Smith',
@@ -35,7 +45,9 @@ It includes timeout support from Python 3.3 but otherwise matches
       url='https://github.com/google/python-subprocess32',
 
       ext_modules=ext_modules,
-      py_modules=['subprocess32'],
+      py_modules=py_modules,
+      packages=packages,
+      package_dir=package_dir,
 
       classifiers=[
           'Intended Audience :: Developers',

--- a/test
+++ b/test
@@ -1,13 +1,23 @@
-#!/bin/bash
+#!/bin/bash -ex
 
 # This is for my own convenience, edit it for your own environment.
 
-PYTHON=../Python-2.4.6/python
-$PYTHON setup.py build || exit 1
-LANG=C PYTHONPATH=./build/lib.linux-x86_64-2.4 $PYTHON test_subprocess32.py || exit 1
+PYTHON=python3.4
+"$PYTHON" -V
+"$PYTHON" setup.py build
+# Merely test that it imports.  Under Python 3, setup.py should've installed a
+# redirection hack making subprocess32 == subprocess.  We cd in order to avoid
+# attempting to import the local subprocess32.py file.
+(cd build && PYTHONPATH=lib "$PYTHON" -c \
+  "import subprocess as s, subprocess32 as s32; assert s is s32, (s, s32)")
+
+PYTHON="../Python-2.4.6/python"
+"$PYTHON" -V
+"$PYTHON" setup.py build
+LANG=C PYTHONPATH=build/lib.linux-x86_64-2.4 "$PYTHON" test_subprocess32.py
 
 PYTHON=python2
-$PYTHON setup.py build || exit 1
-
-export PYTHONPATH=./build/lib.linux-x86_64-2.7
-exec $PYTHON test_subprocess32.py
+"$PYTHON" -V
+"$PYTHON" setup.py build
+export PYTHONPATH=build/lib.linux-x86_64-2.7
+exec "$PYTHON" test_subprocess32.py

--- a/test
+++ b/test
@@ -2,7 +2,7 @@
 
 # This is for my own convenience, edit it for your own environment.
 
-PYTHON=python3.4
+PYTHON=python3
 "$PYTHON" -V
 "$PYTHON" setup.py build
 # Merely test that it imports.  Under Python 3, setup.py should've installed a


### PR DESCRIPTION
#11 Change it to install a dummy module that just redirects
to the standard library subprocess module when built and
installed on Python 3.