### PR TITLE
Fixes so windows can pass tests

### DIFF
--- a/subprocess32.py
+++ b/subprocess32.py
@@ -1141,12 +1141,13 @@ class Popen(object):
             attribute."""
             if endtime is not None:
                 timeout = self._remaining_time(endtime)
+            # actual timeout is milliseconds, use timeout as the printable value
             if timeout is None:
-                timeout = _subprocess.INFINITE
+                timeout_millis = _subprocess.INFINITE
             else:
-                timeout = int(timeout * 1000)
+                timeout_millis = int(timeout * 1000)
             if self.returncode is None:
-                result = _subprocess.WaitForSingleObject(self._handle, timeout)
+                result = _subprocess.WaitForSingleObject(self._handle, timeout_millis)
                 if result == _WAIT_TIMEOUT:
                     raise TimeoutExpired(self.args, timeout)
                 self.returncode = _subprocess.GetExitCodeProcess(self._handle)
@@ -1187,11 +1188,11 @@ class Popen(object):
             if self.stdout is not None:
                 self.stdout_thread.join(self._remaining_time(endtime))
                 if self.stdout_thread.isAlive():
-                    raise TimeoutExpired(self.args)
+                    raise TimeoutExpired(self.args, orig_timeout)
             if self.stderr is not None:
                 self.stderr_thread.join(self._remaining_time(endtime))
                 if self.stderr_thread.isAlive():
-                    raise TimeoutExpired(self.args)
+                    raise TimeoutExpired(self.args, orig_timeout)
 
             # Collect the output from and close both pipes, now that we know
             # both have been read successfully.

--- a/test_subprocess32.py
+++ b/test_subprocess32.py
@@ -201,11 +201,12 @@ class ProcessTestCase(BaseTestCase):
     def test_check_output_timeout(self):
         # check_output() function with timeout arg
         try:
+            # Sleeping to avoid busy loop in event test fails and leaves process running
             output = subprocess.check_output(
                     [sys.executable, "-c",
-                     "import sys; sys.stdout.write('BDFL')\n"
+                     "import sys, time; sys.stdout.write('BDFL')\n"
                      "sys.stdout.flush()\n"
-                     "while True: pass"],
+                     "while True: time.sleep(.01)"],
                     timeout=0.5)
         except subprocess.TimeoutExpired, exception:
             self.assertEqual(exception.output, 'BDFL')
@@ -300,7 +301,7 @@ class ProcessTestCase(BaseTestCase):
         temp_dir = self._normalize_cwd(temp_dir)
         self._assert_cwd(temp_dir, sys.executable, cwd=temp_dir)
 
-    #@unittest.skipIf(mswindows, "pending resolution of issue #15533")
+    @unittest.skipIf(mswindows, "pending resolution of issue #15533")
     def test_cwd_with_relative_arg(self):
         # Check that Popen looks for args[0] relative to cwd if args[0]
         # is relative.
@@ -325,7 +326,7 @@ class ProcessTestCase(BaseTestCase):
             os.chdir(saved_dir)
             shutil.rmtree(path)
 
-    #@unittest.skipIf(mswindows, "pending resolution of issue #15533")
+    @unittest.skipIf(mswindows, "pending resolution of issue #15533")
     def test_cwd_with_relative_executable(self):
         # Check that Popen looks for executable relative to cwd if executable
         # is relative (and that executable takes precedence over args[0]).
@@ -903,13 +904,14 @@ class ProcessTestCase(BaseTestCase):
         # triggers a different code path for better coverage.
         proc.wait(timeout=20)
         # Should be -9 because of the proc.kill() from the thread.
-        self.assertEqual(proc.returncode, -9,
-                         msg="unexpected result in wait from main thread")
+        expected_returncode = -9 if not mswindows else 1
+        self.assertEqual(proc.returncode, expected_returncode,
+                         msg="unexpected result in wait from main thread, return code was {}".format(proc.returncode))
 
         # This should be a no-op with no change in returncode.
         proc.wait()
-        self.assertEqual(proc.returncode, -9,
-                         msg="unexpected result in second main wait.")
+        self.assertEqual(proc.returncode, expected_returncode,
+                         msg="unexpected result in second main wait, return code was {}".format(proc.returncode))
 
         t.join()
         # Ensure that all of the thread results are as expected.
@@ -917,8 +919,8 @@ class ProcessTestCase(BaseTestCase):
         # be set by the wrong thread that doesn't actually have it
         # leading to an incorrect value.
         self.assertEqual([('thread-start-poll-result', None),
-                          ('thread-after-kill-and-wait', -9),
-                          ('thread-after-second-wait', -9)],
+                          ('thread-after-kill-and-wait', expected_returncode),
+                          ('thread-after-second-wait', expected_returncode)],
                          results)
 
     def test_issue8780(self):
@@ -932,6 +934,7 @@ class ProcessTestCase(BaseTestCase):
         output = subprocess.check_output([sys.executable, '-c', code])
         self.assert_(output.startswith('Hello World!'), output)
 
+    @unittest.skipIf(mswindows, 'signal test cannot complete on Windows')
     def test_communicate_eintr(self):
         # Issue #12493: communicate() should handle EINTR
         def handler(signum, frame):


### PR DESCRIPTION
* Pass timeout in seconds to exception in windows wait function
* Added a small sleep to test_check_output_timeout to avoid busyloop on failures.
* Fixed cases where return code was expected to be -9 (is 1 on windows) after a kill
* Ensured skip test directive for signals tests and cwd tests.
* Fixed case where orig_timeout was not passed to TimeoutExpired.