### PR TITLE
Fix Popen.wait() when the child process exits to stopped state.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,9 @@
 2016-??-?? 3.2.8
 -----------------
 
+* Fix subprocess.Popen.wait() when the child process has exited to a
+  a stopped instead of terminated state (ex: when under ptrace).
+  https://bugs.python.org/issue29335 
 * Fix a compilation issue regarding O_CLOEXEC not being defined on old
   Linux distros such as RHEL 5.
 

--- a/subprocess32.py
+++ b/subprocess32.py
@@ -1584,7 +1584,8 @@ class Popen(object):
 
         def _handle_exitstatus(self, sts, _WIFSIGNALED=os.WIFSIGNALED,
                 _WTERMSIG=os.WTERMSIG, _WIFEXITED=os.WIFEXITED,
-                _WEXITSTATUS=os.WEXITSTATUS):
+                _WEXITSTATUS=os.WEXITSTATUS, _WIFSTOPPED=os.WIFSTOPPED,
+                _WSTOPSIG=os.WSTOPSIG):
             """All callers to this function MUST hold self._waitpid_lock."""
             # This method is called (indirectly) by __del__, so it cannot
             # refer to anything outside of its local scope."""
@@ -1592,6 +1593,8 @@ class Popen(object):
                 self.returncode = -_WTERMSIG(sts)
             elif _WIFEXITED(sts):
                 self.returncode = _WEXITSTATUS(sts)
+            elif _WIFSTOPPED(sts):
+                self.returncode = -_WSTOPSIG(sts)
             else:
                 # Should never happen
                 raise RuntimeError("Unknown child exit status!")


### PR DESCRIPTION
Fix wait() when the child exits to stopped state (ex: when under ptrace).
https://bugs.python.org/issue29335