### PR TITLE
Add the private _args_from_interpreter_flags API.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,7 +9,10 @@
 * Fix subprocess.Popen.wait() when the child process has exited to a
   a stopped instead of terminated state (ex: when under ptrace).
   https://bugs.python.org/issue29335 
-* Fix a compilation issue regarding O_CLOEXEC not being defined on old
+* Include the private API needed by the multiprocessing module for people who
+  want to drop subprocess32 in as a replacement for their standard library
+  subprocess module.
+* Fix a compilation issue regarding O_CLOEXEC not being defined on ancient
   Linux distros such as RHEL 5.
 
 -----------------

--- a/subprocess32.py
+++ b/subprocess32.py
@@ -222,6 +222,36 @@ PIPE = -1
 STDOUT = -2
 DEVNULL = -3
 
+# This function is only used by multiprocessing, it is here so that people
+# can drop subprocess32 in as a replacement for the stdlib subprocess module.
+
+def _args_from_interpreter_flags():
+    """Return a list of command-line arguments reproducing the current
+    settings in sys.flags and sys.warnoptions."""
+    flag_opt_map = {
+        'debug': 'd',
+        # 'inspect': 'i',
+        # 'interactive': 'i',
+        'optimize': 'O',
+        'dont_write_bytecode': 'B',
+        'no_user_site': 's',
+        'no_site': 'S',
+        'ignore_environment': 'E',
+        'verbose': 'v',
+        'bytes_warning': 'b',
+        'py3k_warning': '3',
+    }
+    args = []
+    for flag, opt in flag_opt_map.items():
+        v = getattr(sys.flags, flag)
+        if v > 0:
+            args.append('-' + opt * v)
+    if getattr(sys.flags, 'hash_randomization') != 0:
+        args.append('-R')
+    for opt in sys.warnoptions:
+        args.append('-W' + opt)
+    return args
+
 
 def _eintr_retry_call(func, *args):
     while True:

--- a/test_subprocess32.py
+++ b/test_subprocess32.py
@@ -2269,6 +2269,14 @@ class HelperFunctionTests(unittest.TestCase):
         # Supplied PATH environment variable
         self.assertSequenceEqual(test_path, get_exec_path(test_env))
 
+    def test_args_from_interpreter_flags(self):
+        if sys.version_info[:2] < (2,6):
+            print "Skipped - only useful on 2.6 and higher."
+            return
+        # Mostly just to call it for code coverage.
+        args_list = subprocess32._args_from_interpreter_flags()
+        self.assertTrue(isinstance(args_list, list), msg=repr(args_list))
+
 
 def reap_children():
     """Use this function at the end of test_main() whenever sub-processes


### PR DESCRIPTION
This is only useful for people replacing their stdlib subprocess module
with subprocess32.  The multiprocessing module needs this function.

Addresses #15.