### PR TITLE
bugfix - missing parameters in constructor

### DIFF
--- a/subprocess32.py
+++ b/subprocess32.py
@@ -995,11 +995,11 @@ class Popen(object):
             if self.stdout is not None:
                 self.stdout_thread.join(self._remaining_time(endtime))
                 if self.stdout_thread.isAlive():
-                    raise TimeoutExpired(self.args)
+                    raise TimeoutExpired(self.args, orig_timeout)
             if self.stderr is not None:
                 self.stderr_thread.join(self._remaining_time(endtime))
                 if self.stderr_thread.isAlive():
-                    raise TimeoutExpired(self.args)
+                    raise TimeoutExpired(self.args, orig_timeout)
 
             # Collect the output from and close both pipes, now that we know
             # both have been read successfully.


### PR DESCRIPTION
When the timeout expires, the TimeoutExpired exception is not built since parameters are wrong. A TypeError is thrown. As a (bad) consequence, program is not killed.
I see  in Python 3.6.3 this has been fixed.