### PR TITLE
Manual name mangling of the shared library.

### DIFF
--- a/_posixsubprocess.c
+++ b/_posixsubprocess.c
@@ -876,7 +876,7 @@ static PyMethodDef module_methods[] = {
 
 
 PyMODINIT_FUNC
-init_posixsubprocess(void)
+init_posixsubprocess32(void)
 {
     PyObject *m;
 
@@ -886,7 +886,7 @@ init_posixsubprocess(void)
         return;
 #endif
 
-    m = Py_InitModule3("_posixsubprocess", module_methods, module_doc);
+    m = Py_InitModule3("_posixsubprocess32", module_methods, module_doc);
     if (m == NULL)
         return;
 }

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def main():
     if sys.version_info[0] == 2:  # PY2
         py_modules.append('subprocess32')
         if os.name == 'posix':
-            ext = Extension('_posixsubprocess', ['_posixsubprocess.c'],
+            ext = Extension('_posixsubprocess32', ['_posixsubprocess.c'],
                             depends=['_posixsubprocess_helpers.c'])
             ext_modules.append(ext)
     else:  # PY3

--- a/subprocess32.py
+++ b/subprocess32.py
@@ -141,7 +141,7 @@ else:
     import pickle
 
     try:
-        import _posixsubprocess
+        import _posixsubprocess32 as _posixsubprocess
     except ImportError:
         _posixsubprocess = None
         import warnings

--- a/test_subprocess32.py
+++ b/test_subprocess32.py
@@ -2199,7 +2199,7 @@ class ProcessTestCasePOSIXPurePython(ProcessTestCase, POSIXProcessTestCase):
         POSIXProcessTestCase.setUp(self)
 
     def tearDown(self):
-        subprocess._posixsubprocess = sys.modules['_posixsubprocess']
+        subprocess._posixsubprocess = sys.modules['_posixsubprocess32']
         POSIXProcessTestCase.tearDown(self)
         ProcessTestCase.tearDown(self)
 


### PR DESCRIPTION
In our organisation we have Python2.7 and Python3.x side by side. 

The directory `$prefix/lib/python2.7/site-packages` is not on the default load path for `$prefix/bin/python2.7` and the `PYTHONPATH` environment variable is used to ensure that the interpreter finds this location. The python3 distribution is more standard.

We have used `pip` and installed the `subprocess32` module as part of the local Python2.7 distribution. Because the `PYTHONPATH` variable applies globally the Python3 distribution will find the `_posixsubprocess.so` file supplied by the `subprocess32` module - and then we get a brutal SEGFAULT.

This patch fixes the issue in our organisation.


[*] OK - no need to tell me this seems like a quite peculiar setup; yes I am fully aware of that - we have *very* limited control over it.
