### PR TITLE
Unset CLOEXEC on pass_fds fds. (#4)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,8 @@
 * Fixed the packaging problem where the stdlib python3_redirect shim is
   supposed to be installed on Python 3.
 * Renamed _posixsubprocess to _posixsubprocess32 for consistency.
+* Unset CLOEXEC on file descriptors given to Popen pass_fds. (GH #4)
+* Drop support for Python 2.4 and 2.5.
 
 -----------------
 2017-10-18 3.5.0rc1

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ On Python 3, it merely redirects the subprocess32 name to subprocess.""",
       # We don't actually "support" 3.3+, we just allow installation there as
       # we install a stub redirecting to the standard library subprocess module
       # under the subprocess32 name.
-      python_requires='>=2.4, !=3.0.*, !=3.1.*, !=3.2.*, <4',
+      python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*, <4',
 
       classifiers=[
           'Intended Audience :: Developers',
@@ -65,8 +65,6 @@ On Python 3, it merely redirects the subprocess32 name to subprocess.""",
           'Operating System :: POSIX :: BSD',
           'Operating System :: POSIX :: Linux',
           'Operating System :: POSIX :: SunOS/Solaris',
-          'Programming Language :: Python :: 2.4',
-          'Programming Language :: Python :: 2.5',
           'Programming Language :: Python :: 2.6',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 2 :: Only',

--- a/test
+++ b/test
@@ -11,11 +11,6 @@ PYTHON=python3
 (cd build && PYTHONPATH=lib "$PYTHON" -c \
   "import subprocess as s, subprocess32 as s32; assert s is s32, (s, s32)")
 
-PYTHON="../Python-2.4.6/python"
-"$PYTHON" -V
-"$PYTHON" setup.py build
-LANG=C PYTHONPATH=build/lib.linux-x86_64-2.4 "$PYTHON" test_subprocess32.py
-
 PYTHON=python2
 "$PYTHON" -V
 "$PYTHON" setup.py build


### PR DESCRIPTION
Unset CLOEXEC on file descriptors given to Popen pass_fds. (GH #4)
Drop support for Python 2.4 and 2.5.