### PR TITLE
Remove the signal.Signals reference (not in 2.7) [#49]

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,10 @@
 -----------------
+2018-05-21 3.5.1
+-----------------
+* Fix AttributeError: 'module' object has no attribute 'Signals' when
+  constructing a CalledProcessError exception.  [#49]
+
+-----------------
 2018-05-13 3.5.0 (3.5.0rc3)
 -----------------
 

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ def main():
 
     setup(
       name='subprocess32',
-      version='3.5.0',
+      version='3.5.1',
       description='A backport of the subprocess module from Python 3 for use on 2.x.',
       long_description="""\
 This is a backport of the subprocess standard library module from

--- a/subprocess32.py
+++ b/subprocess32.py
@@ -67,12 +67,8 @@ class CalledProcessError(SubprocessError):
 
     def __str__(self):
         if self.returncode and self.returncode < 0:
-            try:
-                return "Command '%s' died with %r." % (
-                        self.cmd, signal.Signals(-self.returncode))
-            except ValueError:
-                return "Command '%s' died with unknown signal %d." % (
-                        self.cmd, -self.returncode)
+            return "Command '%s' died with signal %d." % (
+                    self.cmd, -self.returncode)
         else:
             return "Command '%s' returned non-zero exit status %d." % (
                     self.cmd, self.returncode)


### PR DESCRIPTION
Constructing a CalledProcessError when the process died due to a signal
could raise an AttributeError due to this bug.  Github issue #49.

this will be 3.5.1.