### PR TITLE
Avoid passing an unreasonable value to malloc.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,9 @@
 -----------------
+????-MM-DD 3.5.?
+-----------------
+* Disallow rediculiously large numbers (millions) of arguments.  [#54]
+
+-----------------
 2018-06-07 3.5.2
 -----------------
 * Explicitly include <signal.h> in _posixsubprocess_helpers.c; it already

--- a/_posixsubprocess_helpers.c
+++ b/_posixsubprocess_helpers.c
@@ -115,6 +115,11 @@ _PySequence_BytesToCharpArray(PyObject* self)
     argc = PySequence_Size(self);
     if (argc == -1)
         return NULL;
+    /* Avoid 32-bit overflows to malloc() from unreasonable values. */
+    if (argc > 0x20000000) {
+        PyErr_NoMemory();
+        return NULL;
+    }
 
     array = malloc((argc + 1) * sizeof(char *));
     if (array == NULL) {

--- a/_posixsubprocess_helpers.c
+++ b/_posixsubprocess_helpers.c
@@ -116,7 +116,7 @@ _PySequence_BytesToCharpArray(PyObject* self)
     if (argc == -1)
         return NULL;
     /* Avoid 32-bit overflows to malloc() from unreasonable values. */
-    if (argc > 0x20000000) {
+    if (argc > 0x10000000) {
         PyErr_NoMemory();
         return NULL;
     }

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ def main():
 
     setup(
       name='subprocess32',
-      version='3.5.2',
+      version='3.5.3b0',
       description='A backport of the subprocess module from Python 3 for use on 2.x.',
       long_description="""\
 This is a backport of the subprocess standard library module from


### PR DESCRIPTION
This should address #54.