### PR TITLE
Prevents a potential integer wraparound and heap overflow.

### DIFF
--- a/_posixsubprocess_helpers.c
+++ b/_posixsubprocess_helpers.c
@@ -8,6 +8,7 @@
 #ifdef HAVE_SIGNAL_H
 #include <signal.h>
 #endif
+#include <stdint.h>
 #include "unicodeobject.h"
 
 #if (PY_VERSION_HEX < 0x02050000)
@@ -116,7 +117,14 @@ _PySequence_BytesToCharpArray(PyObject* self)
     if (argc == -1)
         return NULL;
 
-    array = malloc((argc + 1) * sizeof(char *));
+    if ((argc + 1) > SIZE_MAX / sizeof(char *)) {
+        PyErr_SetNone(PyExc_OverflowError);
+        return NULL;
+    }
+    else {
+        array = malloc((argc + 1) * sizeof(char *));
+    }
+
     if (array == NULL) {
         PyErr_NoMemory();
         return NULL;


### PR DESCRIPTION
Attempts to address #54.

Before:

```bash
$ ./crash.py 
*** glibc detected *** /usr/bin/python: double free or corruption (!prev): 0x089c9b38 ***
Segmentation fault (core dumped)
```

After:

```bash
$ ./crash.py 
Traceback (most recent call last):
  File "./crash.py", line 3, in <module>
    subprocess._posixsubprocess.fork_exec("a",'a'*0x3FFFFFFF,"a",set(),"a","a",1,1,1,1,1,1,1,3,1,1,"a")
OverflowError
```



