### PR TITLE
Handle "broken pipe" errors in communicate

### DIFF
--- a/subprocess32.py
+++ b/subprocess32.py
@@ -682,6 +682,10 @@ class Popen(object):
             self._devnull = os.open(os.devnull, os.O_RDWR)
         return self._devnull
 
+    def _stdin_write(self, input):
+        if input:
+            self.stdin.write(input)
+        self.stdin.close()
 
     def communicate(self, input=None, timeout=None):
         """Interact with process: Send data to stdin.  Read data from
@@ -708,9 +712,7 @@ class Popen(object):
             stdout = None
             stderr = None
             if self.stdin:
-                if input:
-                    self.stdin.write(input)
-                self.stdin.close()
+                self._stdin_write(input)
             elif self.stdout:
                 stdout = _eintr_retry_call(self.stdout.read)
                 self.stdout.close()

--- a/subprocess32.py
+++ b/subprocess32.py
@@ -41,6 +41,7 @@ import sys
 mswindows = (sys.platform == "win32")
 
 import os
+import errno
 import exceptions
 import types
 import time
@@ -132,7 +133,6 @@ if mswindows:
 else:
     import select
     _has_poll = hasattr(select, 'poll')
-    import errno
     import fcntl
     import pickle
 

--- a/subprocess32.py
+++ b/subprocess32.py
@@ -690,13 +690,18 @@ class Popen(object):
                 if e.errno == errno.EPIPE:
                     # communicate() must ignore broken pipe error
                     pass
+                elif e.errno == errno.EINVAL :
+                    # bpo-19612, bpo-30418: On Windows, stdin.write() fails
+                    # with EINVAL if the child process exited or if the child
+                    # process is still running but closed the pipe.
+                    pass
                 else:
                     raise
 
         try:
             self.stdin.close()
         except EnvironmentError as e:
-            if e.errno == errno.EPIPE:
+            if e.errno in (errno.EPIPE, errno.EINVAL):
                 pass
             else:
                 raise

--- a/test_subprocess32.py
+++ b/test_subprocess32.py
@@ -999,6 +999,25 @@ class ProcessTestCase(BaseTestCase):
         output = subprocess.check_output([sys.executable, '-c', code])
         self.assert_(output.startswith('Hello World!'), output)
 
+    def test_communicate_epipe(self):
+        # Issue 10963: communicate() should hide EPIPE
+        p = subprocess.Popen([sys.executable, "-c", 'pass'],
+                             stdin=subprocess.PIPE,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
+        self.addCleanup(p.stdout.close)
+        self.addCleanup(p.stderr.close)
+        self.addCleanup(p.stdin.close)
+        p.communicate(b"x" * 2**20)
+
+    def test_communicate_epipe_only_stdin(self):
+        # Issue 10963: communicate() should hide EPIPE
+        p = subprocess.Popen([sys.executable, "-c", 'pass'],
+                             stdin=subprocess.PIPE)
+        self.addCleanup(p.stdin.close)
+        p.wait()
+        p.communicate(b"x" * 2**20)
+
     if not mswindows:  # Signal tests are POSIX specific.
         def test_communicate_eintr(self):
             # Issue #12493: communicate() should handle EINTR


### PR DESCRIPTION
This fixes #61 by catching EPIPE errors when writing to stdin of the child process.
